### PR TITLE
Fix IAX call-limit variable

### DIFF
--- a/protected/components/AsteriskAccess.php
+++ b/protected/components/AsteriskAccess.php
@@ -941,7 +941,7 @@ class AsteriskAccess
                         }
 
                         if ($iax->calllimit > 0) {
-                            $line .= 'call-limit=' . $sip->calllimit . "\n";
+                            $line .= 'call-limit=' . $iax->calllimit . "\n";
                         }
 
                         if (fwrite($fd, $line) === false) {


### PR DESCRIPTION
## Summary
- fix wrong variable reference when generating IAX peers

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683dd8b2deb48321a5ed32254d3167c0